### PR TITLE
Params page - UUIDv4 - Scroll to top - cards click into param'd page - filter amiibo series per param page

### DIFF
--- a/src/components/AmiiboCard.tsx
+++ b/src/components/AmiiboCard.tsx
@@ -1,4 +1,5 @@
 import { Amiibo } from '../interfaces/amiiboInterface';
+import { Link } from 'react-router-dom';
 
 import styled from '@emotion/styled';
 
@@ -57,16 +58,18 @@ export default function AmiiboCard({ amiiboProps }: Props) {
     return (
         <Wrapper>
             {amiiboProps.map((amiibo: Amiibo) => (
-                <Card
-                    key={`${amiibo.gameSeries}-${amiibo.name}-${amiibo.character}-${amiibo.tail}`}
-                >
-                    <CardInfo>
-                        <p>{amiibo.name}</p>
-                    </CardInfo>
-                    <InnerCard>
-                        <CardImg src={amiibo.image} />
-                    </InnerCard>
-                </Card>
+                <Link to={`/amiibos/${amiibo.id}`}>
+                    <Card
+                        key={`${amiibo.gameSeries}-${amiibo.name}-${amiibo.character}-${amiibo.tail}`}
+                    >
+                        <CardInfo>
+                            <p>{amiibo.name}</p>
+                        </CardInfo>
+                        <InnerCard>
+                            <CardImg src={amiibo.image} />
+                        </InnerCard>
+                    </Card>
+                </Link>
             ))}
         </Wrapper>
     );

--- a/src/components/AmiiboCard.tsx
+++ b/src/components/AmiiboCard.tsx
@@ -58,10 +58,11 @@ export default function AmiiboCard({ amiiboProps }: Props) {
     return (
         <Wrapper>
             {amiiboProps.map((amiibo: Amiibo) => (
-                <Link to={`/amiibos/${amiibo.id}`}>
-                    <Card
-                        key={`${amiibo.gameSeries}-${amiibo.name}-${amiibo.character}-${amiibo.tail}`}
-                    >
+                <Link
+                    to={`/amiibos/${amiibo.id}`}
+                    key={`${amiibo.gameSeries}-${amiibo.name}-${amiibo.character}-${amiibo.tail}`}
+                >
+                    <Card>
                         <CardInfo>
                             <p>{amiibo.name}</p>
                         </CardInfo>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,13 @@
+// Based on code snippet provided by React Router Documentation.
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+}

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -2,6 +2,7 @@ import { Global, css } from '@emotion/react';
 import { ReactNode } from 'react';
 import { Outlet } from 'react-router-dom';
 import styled from '@emotion/styled';
+import ScrollToTop from './ScrollToTop';
 
 import Navbar from './Navbar';
 import Footer from './Footer';
@@ -14,7 +15,8 @@ const GlobalStyles = () => (
                 padding: 0;
                 box-sizing: border-box;
             }
-            html, body {
+            html,
+            body {
                 width: 100%;
                 height: 100%;
                 overflow-x: hidden;
@@ -42,6 +44,7 @@ export default function Root({ children }: { children?: ReactNode }) {
         <>
             <GlobalStyles />
             <Container>
+                <ScrollToTop />
                 <Navbar />
                 {children || <Outlet />}
                 <AlignFooter>

--- a/src/interfaces/amiiboInterface.ts
+++ b/src/interfaces/amiiboInterface.ts
@@ -1,4 +1,5 @@
 export interface Amiibo {
+    release: any;
     id: any;
     gameSeries: string;
     name: string;

--- a/src/interfaces/amiiboInterface.ts
+++ b/src/interfaces/amiiboInterface.ts
@@ -1,4 +1,5 @@
 export interface Amiibo {
+    id: any;
     gameSeries: string;
     name: string;
     image: string;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import AmiiboList from './components/AmiiboList.tsx';
 import Compare from './pages/Compare.tsx';
 import Signup from './pages/Signup.tsx';
 import LoginPage from './pages/LoginPage.tsx';
+import AmiibosParams from './pages/AmiibosParams.tsx';
 
 import Theme from './assets/theme.ts';
 import { Global } from '@emotion/react';
@@ -29,6 +30,7 @@ const router = createBrowserRouter([
         children: [
             { index: true, element: <Home /> },
             { path: 'amiibos', element: <AmiiboList /> },
+            { path: 'amiibos/:id', element: <AmiibosParams /> },
             { path: 'compare', element: <Compare /> },
             { path: 'signup', element: <Signup /> },
             { path: 'login', element: <LoginPage /> },

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -1,6 +1,19 @@
 import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../redux/hooks';
 import { Amiibo } from '../interfaces/amiiboInterface';
+import { Link } from 'react-router-dom';
+
+import styled from '@emotion/styled';
+
+const ImgWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const ContainImg = styled.img`
+    width: 100px;
+    height: auto;
+`;
 
 export default function AmiibosParams() {
     const parameters = useParams();
@@ -10,6 +23,10 @@ export default function AmiibosParams() {
     const amiiboDataRedux: Amiibo[] = useAppSelector((state) => state.allAmiiboSlice.amiibos);
     const selectedAmiibo = amiiboDataRedux.find((amiibo) => amiibo.id === id);
 
+    // log store.
+    console.log('Redux store for single amiibo: ', selectedAmiibo);
+    console.log('Redux store for ALL amiibo: ', amiiboDataRedux);
+
     // Logic to ensure amiibo exist.
     if (!selectedAmiibo) {
         return <div>Loading...</div>; // This should change.
@@ -18,9 +35,18 @@ export default function AmiibosParams() {
     return (
         <div>
             <h1>{selectedAmiibo.name}</h1>
-            <img src={selectedAmiibo.image} alt={selectedAmiibo.name} />
+            <ImgWrapper>
+                <ContainImg src={selectedAmiibo.image} />
+            </ImgWrapper>
+
             <p>Game Series: {selectedAmiibo.gameSeries}</p>
+            <p>Amiibo Series: {selectedAmiibo.amiiboSeries}</p>
             <p>Character: {selectedAmiibo.character}</p>
+            <h3>Release Date: </h3>
+            <p>Australia: {selectedAmiibo.release.au}</p>
+            <p>Europe: {selectedAmiibo.release.eu}</p>
+            <p>Japan: {selectedAmiibo.release.jp}</p>
+            <p>North America: {selectedAmiibo.release.na}</p>
         </div>
     );
 }

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+export default function AmiibosParams() {
+    const parameters = useParams();
+    const { id } = parameters;
+    return <h1>{id}</h1>;
+}

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -12,7 +12,7 @@ export default function AmiibosParams() {
 
     // Logic to ensure amiibo exist.
     if (!selectedAmiibo) {
-        return <div>Loading...</div>; // You can render a loading indicator here
+        return <div>Loading...</div>; // This should change.
     }
 
     return (

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -27,9 +27,20 @@ export default function AmiibosParams() {
     console.log('Redux store for single amiibo: ', selectedAmiibo);
     console.log('Redux store for ALL amiibo: ', amiiboDataRedux);
 
+    // Find the amiibo within the same series, based on all amiibo state.
+    // Use this to filter additional amiibo wihtin the same series.
+    const sameSeries = amiiboDataRedux.filter(
+        (amiibo) => amiibo.amiiboSeries === selectedAmiibo?.amiiboSeries && amiibo.id !== id
+    );
+
     // Logic to ensure amiibo exist.
     if (!selectedAmiibo) {
-        return <div>Loading...</div>; // This should change.
+        return (
+            <div>
+                Loading Amiibo...if there is an error, try again. (Fix this! Amiibo should have one
+                unique ID, and not change on reload...)
+            </div>
+        ); // This should change.
     }
 
     return (
@@ -47,6 +58,15 @@ export default function AmiibosParams() {
             <p>Europe: {selectedAmiibo.release.eu}</p>
             <p>Japan: {selectedAmiibo.release.jp}</p>
             <p>North America: {selectedAmiibo.release.na}</p>
+
+            <h3>Other Amiibos in the Same Series:</h3>
+            <ul>
+                {sameSeries.map((amiibo) => (
+                    <li key={amiibo.id}>
+                        <Link to={`/amiibos/${amiibo.id}`}>{amiibo.name}</Link>
+                    </li>
+                ))}
+            </ul>
         </div>
     );
 }

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -1,12 +1,13 @@
 import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../redux/hooks';
+import { Amiibo } from '../interfaces/amiiboInterface';
 
 export default function AmiibosParams() {
     const parameters = useParams();
     const { id } = parameters;
 
     // Access redux store for particular amiibo.
-    const amiiboDataRedux = useAppSelector((state) => state.allAmiiboSlice.amiibos);
+    const amiiboDataRedux: Amiibo[] = useAppSelector((state) => state.allAmiiboSlice.amiibos);
     const selectedAmiibo = amiiboDataRedux.find((amiibo) => amiibo.id === id);
 
     // Logic to ensure amiibo exist.

--- a/src/pages/AmiibosParams.tsx
+++ b/src/pages/AmiibosParams.tsx
@@ -1,7 +1,25 @@
 import { useParams } from 'react-router-dom';
+import { useAppSelector } from '../redux/hooks';
 
 export default function AmiibosParams() {
     const parameters = useParams();
     const { id } = parameters;
-    return <h1>{id}</h1>;
+
+    // Access redux store for particular amiibo.
+    const amiiboDataRedux = useAppSelector((state) => state.allAmiiboSlice.amiibos);
+    const selectedAmiibo = amiiboDataRedux.find((amiibo) => amiibo.id === id);
+
+    // Logic to ensure amiibo exist.
+    if (!selectedAmiibo) {
+        return <div>Loading...</div>; // You can render a loading indicator here
+    }
+
+    return (
+        <div>
+            <h1>{selectedAmiibo.name}</h1>
+            <img src={selectedAmiibo.image} alt={selectedAmiibo.name} />
+            <p>Game Series: {selectedAmiibo.gameSeries}</p>
+            <p>Character: {selectedAmiibo.character}</p>
+        </div>
+    );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,14 +36,14 @@ export default function Home() {
 
     // Selecting amiibo data from the redux store...
     const amiiboDataRedux = useAppSelector((state) => state.allAmiiboSlice.amiibos);
-    console.log('Testing...: ', amiiboDataRedux);
+    // console.log('Testing...: ', amiiboDataRedux);
 
     // Filter amiibo data based on allAmiibo state
     const filterAmiiboAllOrRecent = allAmiibo
         ? amiiboDataRedux
         : filterRecentReleases(amiiboDataRedux);
 
-    console.log('Recent...: ', filterAmiiboAllOrRecent);
+    // console.log('Recent...: ', filterAmiiboAllOrRecent);
 
     if (isLoading) return <p>Loading...</p>;
     if (error) return <p>{error.message}</p>;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -11,6 +11,25 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { faMinus } from '@fortawesome/free-solid-svg-icons';
 
+const Container = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+const UserInfoContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    border: 2px solid black;
+    border-radius: 7px;
+    margin: 2rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+`;
+
+const UserInfo = styled.div`
+    margin-top: 2rem;
+`;
+
 const ExpandButton = styled.button`
     background: transparent;
     border: none;
@@ -52,17 +71,33 @@ export default function Home() {
         <>
             <h1>Amiibo Atlas</h1>
             <img src={myImage} />
-            <h2>
-                {toggle ? 'Every Amiibo' : 'Recently Released Amiibo'} |
-                <ExpandButton onClick={handleExpansion}>
-                    {toggle ? (
-                        <FontAwesomeIcon icon={faMinus} />
-                    ) : (
-                        <FontAwesomeIcon icon={faPlus} />
-                    )}
-                </ExpandButton>
-            </h2>
-            <AmiiboCard amiiboProps={filterAmiiboAllOrRecent} />
+            <Container>
+                <UserInfoContainer>
+                    <UserInfo>
+                        <h2>User info:</h2>
+                        <p>TO DO: Hook into Redux store</p>
+                        <p>Select User Session</p>
+                        <p>Display User options</p>
+                    </UserInfo>
+                    <UserInfo>
+                        <h3>User Wishlist</h3>
+                        <p>TO DO: Hook into Redux store</p>
+                        <p>Select User Session</p>
+                        <p>Display Current User Wishlist here from global state</p>
+                    </UserInfo>
+                </UserInfoContainer>
+                <h2>
+                    {toggle ? 'Every Amiibo' : 'Recently Released Amiibo'} |
+                    <ExpandButton onClick={handleExpansion}>
+                        {toggle ? (
+                            <FontAwesomeIcon icon={faMinus} />
+                        ) : (
+                            <FontAwesomeIcon icon={faPlus} />
+                        )}
+                    </ExpandButton>
+                </h2>
+                <AmiiboCard amiiboProps={filterAmiiboAllOrRecent} />
+            </Container>
         </>
     );
 }

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -90,18 +90,18 @@ function WishlistPage() {
     const [defaultWish, setDefaultWishlist] = useState<Amiibo[]>(defaultWishlist);
     const [popupOpen, setPopupOpen] = useState(false);
     const [isPublic, setIsPublic] = useState(false);
-    const [type, setType] = useState("");
+    const [type, setType] = useState('');
     const [publicCall, setPublicCall] = useState(false);
     const togglePopup = () => {
-        setType("sharing");
+        setType('sharing');
         setPopupOpen(!popupOpen);
     };
 
     const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
-        console.log("Wishlist Public:", e.target.checked);
-        setType("public");
-        setPublicCall(!publicCall); 
-      }
+        console.log('Wishlist Public:', e.target.checked);
+        setType('public');
+        setPublicCall(!publicCall);
+    };
 
     const dispatch = useAppDispatch();
     useAppSelector((state) => state.setUser.wishlist);
@@ -119,9 +119,14 @@ function WishlistPage() {
         <Page>
             <h1 id="page-title">Wishlist</h1>
             <label>
-                <input id="checkbox" type="checkbox" checked={isPublic}
-                onChange={handleOnChange} onClick={togglePopup}/>
-       </label>
+                <input
+                    id="checkbox"
+                    type="checkbox"
+                    checked={isPublic}
+                    onChange={handleOnChange}
+                    onClick={togglePopup}
+                />
+            </label>
             <p className="route-directory">Home - Wishlist</p>
             <h3>Explore or remove items form your Wish List here. </h3>
             <p>Item Count: {defaultWish.length}</p>
@@ -130,18 +135,28 @@ function WishlistPage() {
                 <Button id="share-button" onClick={togglePopup}>
                     <FiShare /> Share Wishlist!
                 </Button>
-                {<Popup showPopup={popupOpen} setShowPopup={setPopupOpen} type={type} publicStatus={isPublic} setPublicStatus={setIsPublic} />}
+                {
+                    <Popup
+                        showPopup={popupOpen}
+                        setShowPopup={setPopupOpen}
+                        type={type}
+                        publicStatus={isPublic}
+                        setPublicStatus={setIsPublic}
+                    />
+                }
             </div>
 
-            {isPublic && <Wishes>
-                {defaultWishlist.map((wish) => (
-                    <WishItem
-                        amiiboWish={wish}
-                        key={`${wish.gameSeries} - ${wish.name}}`}
-                        onRemove={removeWishlistItem}
-                    />
-                ))}
-            </Wishes>}
+            {isPublic && (
+                <Wishes>
+                    {defaultWishlist.map((wish) => (
+                        <WishItem
+                            amiiboWish={wish}
+                            key={`${wish.gameSeries} - ${wish.name}}`}
+                            onRemove={removeWishlistItem}
+                        />
+                    ))}
+                </Wishes>
+            )}
         </Page>
     );
 }

--- a/src/pages/WishlistPage.tsx
+++ b/src/pages/WishlistPage.tsx
@@ -52,6 +52,8 @@ function WishlistPage() {
             name: 'Metal Mario - Tennis',
             image: 'https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_09d00301-02bb0e02.png',
             tail: '02bb0e02',
+            release: undefined,
+            id: undefined,
         },
         {
             character: 'Mario Cereal',
@@ -60,6 +62,8 @@ function WishlistPage() {
             name: 'Super Mario Cereal',
             image: 'https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_37400001-03741402.png',
             tail: '03741402',
+            release: undefined,
+            id: undefined,
         },
         {
             character: 'Baby Mario',
@@ -68,6 +72,8 @@ function WishlistPage() {
             name: 'Baby Mario - Soccer',
             image: 'https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_09cc0101-02a50e02.png',
             tail: '02a50e02',
+            release: undefined,
+            id: undefined,
         },
         {
             character: 'Metal Mario',
@@ -76,6 +82,8 @@ function WishlistPage() {
             name: 'Metal Mario - Soccer',
             image: 'https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_09d00101-02b90e02.png',
             tail: '02b90e02',
+            release: undefined,
+            id: undefined,
         },
         {
             character: 'Mario',
@@ -84,6 +92,8 @@ function WishlistPage() {
             name: 'Mario - Soccer',
             image: 'https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/images/icon_09c00101-02690e02.png',
             tail: '02690e02',
+            release: undefined,
+            id: undefined,
         },
     ];
 

--- a/src/redux/getAllAmiibo.ts
+++ b/src/redux/getAllAmiibo.ts
@@ -5,7 +5,11 @@ export const allAmiiboSlice = createSlice({
     initialState: { amiibos: [] },
     reducers: {
         getAmiibo: (state, action) => {
-            state.amiibos = action.payload;
+            // state.amiibos = action.payload;
+            state.amiibos = action.payload.map((amiibo) => ({
+                ...amiibo,
+                id: amiibo.id,
+            }));
         },
     },
 });

--- a/src/requests/fetchAmiiboList.ts
+++ b/src/requests/fetchAmiiboList.ts
@@ -3,12 +3,18 @@ import { useQuery } from '@tanstack/react-query';
 import { getAmiibo } from '../redux/getAllAmiibo';
 import store from '../redux/store';
 
+import { v4 as uuidv4 } from 'uuid';
+
 export async function fetchAmiiboList(API: string) {
     const response = await axios.get(`${API}`);
     if (response.status < 200 || response.status >= 400) {
         throw new Error(response.statusText);
     }
-    return response.data.amiibo;
+
+    return response.data.amiibo.map((amiibo) => ({
+        ...amiibo,
+        id: amiibo.id || uuidv4(),
+    }));
 }
 
 export default function GetAmiibo() {


### PR DESCRIPTION
It's been a busy week with midterms, as well as other job responsibilities. Hopefully this is decent enough.

- Every amiibo within its global state has a unique ID. NOTE: Upon reload, the ID WILL change. This is because the amiibo ID does NOT assign an ID. Therefore, after the API is called, I am assigning a unique ID per the amiibo. Since we are currently running locally, and the ID is being assigned after the call to dispatch into the store, that means the ID is being generated each time. There should be a better, proper way for this, but for now this will do. 
- Homepage has a sidebar that will contain information regarding the user. This information is based on the redux store. We need to determine user session information from an authorized user. Meaning, once a user log ins, we need to store a session in for x days, and incorporate that to the slice for userInfo. 
- Parameterized page created for each amiibo. Displays basic information now, as well as links to amiibos within the same amiibo family. The parameterized page links to the particular amiibo's ID (based on the ID generated by the UUID library).
- Scroll to top: Notice that when you click a page and go into the next one, it doesn't scroll to the very top. I wasn't able to get this working in time for the progress report, but it should soon.