### PR TITLE
Profile Page UI Tweaks / Card UI Tweaks

### DIFF
--- a/src/components/AmiiboList/AmiiboList.tsx
+++ b/src/components/AmiiboList/AmiiboList.tsx
@@ -185,6 +185,7 @@ const AmiiboList = () => {
                                 amiibo={amiibo}
                                 onClickDetail={() => handleViewMore(amiibo)}
                                 onClickWishlist={() => handleAddWishlist(amiibo)}
+                                userId={userId}
                             />
                         ))}
                     </GridContainer>

--- a/src/components/AmiiboList/AmiiboListStyles.tsx
+++ b/src/components/AmiiboList/AmiiboListStyles.tsx
@@ -220,4 +220,26 @@ export const Button = css`
         box-shadow: none;
     }
 `;
+
+export const WishButton = styled.button<{ wished: boolean }>`
+    color:  ${({ wished }) => (wished ? "white" :  "black" )};
+    border: ${({ wished }) => (wished ? "2px solid #f80001" :  "2px solid black" )};
+    padding: 10px;
+    background-color: ${({ wished }) => (wished ? "#f80001" :  "white" )};
+    text-align: center;
+    text-decoration: none;
+    font-size: 12px;
+    cursor: pointer;
+    border-radius: 999px;
+    text-transform: uppercase;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    line-height: 19px;
+    &:hover {
+        border: 2px solid #f80001;
+        box-shadow: none;
+        // cursor: default;  // can click on it to see warning message.
+    }
+`;
 /***************** Card.tsx *****************/

--- a/src/components/AmiiboList/Card.tsx
+++ b/src/components/AmiiboList/Card.tsx
@@ -1,7 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import { CardContainer, ImageContainer, CardImage, CardTitle, CardFooter, Button } from './AmiiboListStyles';
+import { CardContainer, ImageContainer, CardImage, CardTitle, CardFooter, Button, WishButton } from './AmiiboListStyles';
+import {filterWishedAmiibos} from '../../features/amiibo/wishedAmiibos';
 
-const Card = ({ amiibo, onClickDetail, onClickWishlist }) => {
+const Card = ({ amiibo, onClickDetail, onClickWishlist, userId }) => {
+    // returns an array with the amiibo and a boolean determining whether or not
+    // the amiibo exists in the user's wishlist
+    const item = filterWishedAmiibos(amiibo, userId);
+
     return (
         <CardContainer>
             <ImageContainer>
@@ -10,7 +15,8 @@ const Card = ({ amiibo, onClickDetail, onClickWishlist }) => {
             <CardTitle>{amiibo.name} ({amiibo.amiiboSeries})</CardTitle>
             <CardFooter>
                 <button css={Button} onClick={onClickDetail}>View More</button>
-                <button css={Button} onClick={onClickWishlist}>Wishlist</button>
+                {/* <button css={Button} onClick={onClickWishlist}>Wishlist</button> */}
+                <WishButton wished={item[1]} onClick={onClickWishlist}>Wishlist</WishButton>
             </CardFooter>
         </CardContainer>
     );

--- a/src/components/UserDashboard/AmiiboItem.tsx
+++ b/src/components/UserDashboard/AmiiboItem.tsx
@@ -62,7 +62,7 @@ const Button = css`
     letter-spacing: 0.5px;
     line-height: 19px;
     &:hover {
-        border-color: #646cff;
+        border-color: #f80001;
     }
     margin-bottom: auto;
 `;

--- a/src/components/UserDashboard/ProfilePage.tsx
+++ b/src/components/UserDashboard/ProfilePage.tsx
@@ -1,10 +1,7 @@
 // Dependencies
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import styled from '@emotion/styled';
-import { FaUserEdit } from 'react-icons/fa';
-import { FaHeart } from 'react-icons/fa';
-import { NavLink } from 'react-router-dom';
+import { FiShare } from 'react-icons/fi';
 
 // Components
 import { getUser, getWishlist } from '../../features/user/userAPI';
@@ -12,39 +9,24 @@ import { Amiibo } from '../../types/Amiibo';
 import { User } from '../../types/User';
 import AmiiboItem from './AmiiboItem';
 
-const ContainPage = styled.div`
-    display: flex;
-    flex-direction: column;
-    margin: 2rem;
-`;
+// Styles
+import {
+    PageContainer,
+    MainContent,
+    OnlineStatus,
+    ImageBox,
+    ProfileContainer,
+    ShareButton,
+    ProfileName,
+    ProfileContent,
+    ProfileCount,
+    BottomContainer,
+    RightSection,
+    LeftSection, 
+    Collection,
+} from './ProfilePageStyles';
 
-const MainContent = styled.div`
-    justify-content: center;
-    align-items: center;
-`;
 
-const ImageBox = styled.div`
-    background-color: white;
-    border: 5px black solid;
-    border-radius: 50%;
-    height: 75px;
-    width: 75px;
-    display: inline-block;
-    top: 0;
-`;
-
-const OnlineStatus = styled.label<{ online: boolean }>`
-    background: ${({ online }) => (online ? "#00FF40" :  "grey" )};
-    width: 10px;
-    height: 10px;
-    border: 2px solid black;
-    border-radius: 20px;
-    margin: 25px 10px;
-`;
-
-const ProfileContent = styled.div`
-    display: inline-flex;
-`;
 
 function ProfilePage() {
     // Get the user ID from the URL
@@ -65,29 +47,34 @@ function ProfilePage() {
     }, [userId]);
 
     return (
-        <ContainPage>
+        <PageContainer>
             <MainContent>
-                <ImageBox />
-                <ProfileContent>
-                    <div className="photo-box"></div>
-                    <h3>{user?.displayName}</h3>
-                    <OnlineStatus online={user != null} />
-                </ProfileContent>
-                <button>
-                    Edit Profile! <FaUserEdit />
-                </button>
-                <NavLink to={`/users/${userId}/wishlist`}>Wishlist ! <FaHeart /></NavLink>
-                <div className="personal-collection">
-                    {wishlist.map((amiibo) => (
-                        <AmiiboItem
-                            amiibo={amiibo}
-                            key={`${amiibo.gameSeries} - ${amiibo.name}`}
-                            setWishlist={setWishlist}
-                        />
-                    ))}
-                </div>
+                <ProfileContainer>
+                    <ProfileContent>
+                        <ImageBox src={user?.profile_picture} />
+                        <ProfileName>{user?.displayName}</ProfileName>
+                        <OnlineStatus online={user != null} />
+                    </ProfileContent>
+                    <ProfileCount>CURRENT WISH COUNT: {wishlist?.length}</ProfileCount>
+                    <ShareButton> <FiShare /> Share Wishlist!</ShareButton>
+                </ProfileContainer>
+
+                <BottomContainer>
+                    <LeftSection>
+                    <Collection>
+                        {wishlist.map((amiibo) => (
+                            <AmiiboItem
+                                amiibo={amiibo}
+                                key={`${amiibo.gameSeries} - ${amiibo.name}`}
+                                setWishlist={setWishlist}
+                            />
+                        ))}
+                    </Collection>
+                    </LeftSection>
+                    <RightSection />  
+                </BottomContainer>
             </MainContent>
-        </ContainPage>
+        </PageContainer>
     );
 }
 

--- a/src/components/UserDashboard/ProfilePageStyles.tsx
+++ b/src/components/UserDashboard/ProfilePageStyles.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @emotion/react */
+import styled from '@emotion/styled';
+import { Button } from '../AmiiboList/AmiiboListStyles';
+
+export const PageContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 2rem;
+`;
+
+export const MainContent = styled.div`
+    margin: auto;
+`;
+
+export const OnlineStatus = styled.label<{ online: boolean }>`
+    background: ${({ online }) => (online ? "#00FF40" :  "grey" )};
+    width: 10px;
+    height: 10px;
+    border: 2px solid black;
+    border-radius: 20px;
+    margin-top: 28px;
+    min-width: 10px;
+    min-height: 10px;
+`;
+
+export const ImageBox = styled.img`
+    border: 1px solid #ddd;
+    border-radius: 50%;
+    height: 100px;
+    width: 100px;
+`;
+
+export const ProfileContainer = styled.div`
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 15px;
+    width: 90vw;
+    height: 200px;
+    margin: auto;
+    padding: 50px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+    display: inline-block;
+`;
+
+export const ShareButton = styled.button`
+    ${Button};
+    top: 30%;
+    left: 11%;
+`;
+
+export const ProfileName = styled.h3`
+    text-align: left;
+    min-width: 15px;
+    margin-top: 11px;
+    padding: 15px;
+`;
+
+export const ProfileContent = styled.div`
+    display: inline-flex;
+    position: relative;
+`;
+
+export const ProfileCount = styled.p`
+    top: 21%;
+    left: 11%;
+    width: 100%;
+`;
+
+export const BottomContainer = styled.div`
+    display: flex; 
+    flex-wrap: wrap;
+    justify-content: space-between;
+    padding-bottom: 5em;
+    align-items: center;
+`;
+
+export const RightSection = styled.div`
+    border: 2px solid black;
+    flex: 5;
+    display: flex;
+    height: 50px;
+`;
+
+export const LeftSection = styled.div`
+    flex: 5;
+    text-align: center;
+    display: flex;
+    width: 50%;
+`;
+
+export const Collection = styled.div`  
+    margin: auto;
+`;

--- a/src/features/amiibo/wishedAmiibos.ts
+++ b/src/features/amiibo/wishedAmiibos.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+import { Amiibo } from '../../types/Amiibo';
+import { getWishlist } from '../user/userAPI';
+
+export function filterWishedAmiibos(amiibo, userId) {
+    const [status, setStatus] = useState(false);
+
+    const handleWishedStatus = async (userId) => {
+
+        const wishlist = await getWishlist(userId)
+        setStatus(wishlist.map(item => item.image).includes(amiibo.image));
+        
+    }
+    handleWishedStatus(userId);
+    return [amiibo, status];
+};


### PR DESCRIPTION
# Card now shows if the amiibo is in the wishlist:
![image](https://github.com/Amiibo-Atlas/Amiibo-Atlas/assets/102545685/ec18982a-4fa5-4805-af2a-8b3744431bed)
### Affected files: 
* AmiiboList.tsx -> to access Card Component
* AmiiboListStyles.tsx -> for UI
* Card.tsx -> calls the filter function to update the Wishlist button.
* wishedAmiibo.ts -> where the function for the filtering is - currently in features/amiibo (feel free to move this, wasn't sure where to place this)

# Profile Page: 
![image](https://github.com/Amiibo-Atlas/Amiibo-Atlas/assets/102545685/887f16d6-7751-45be-a1ba-83beb9d22f76)
### Changes:
* Included profile picture, wishlist count, and share button in the profile box.
* new components for the bottom (Bottom Container) - below the profile box - currently, split into LeftSection and RightSection with LeftSection holding the wishlist. 
   * the black box border can be deleted, i was just using it for spacing tests. 
* Feel free to add something to right section or we can just get rid of the extra components and keep the wishlist in the middle. 

### Affected Files: 
* ProfilePageStyles.tsx - lots of styling so i moved it into a diff file like the AmiiboListStyles
* ProfilePage.tsx - new changes for components.
* AmiiboItems.tsx - changed color for details button. 