### PR TITLE
Resolving Amiibo Param Page issue 2

### DIFF
--- a/src/components/AmiiboList/AmiiboDetail.tsx
+++ b/src/components/AmiiboList/AmiiboDetail.tsx
@@ -3,6 +3,7 @@ import { useAppSelector } from '../../redux/hooks';
 import { AmiiboState } from '../../types/Amiibo';
 import Breadcrumb from '../shared/Breadcrumb';
 import { Amiibo } from '../../types/Amiibo';
+import AmiiboCard from '../AmiiboCard';
 import { Link } from 'react-router-dom';
 
 // Styles
@@ -59,17 +60,7 @@ const AmiiboDetail = () => {
                             <p>Release Date: {selectedAmiibo?.release.na}</p>
 
                             <h3>Other Amiibos in the Same Series:</h3>
-                            {
-                                <ul>
-                                    {sameSeries.map((amiibo) => (
-                                        <li key={amiibo.id}>
-                                            <Link to={`/amiibos/${amiibo.tail}-${amiibo.head}`}>
-                                                {amiibo.name}
-                                            </Link>
-                                        </li>
-                                    ))}
-                                </ul>
-                            }
+                            {<AmiiboCard amiiboProps={sameSeries.slice(0, 3)}></AmiiboCard>}
                         </div>
                     </ColMd8>
                 </div>


### PR DESCRIPTION
Improved UI of AmiiboDetail (originally AmiiboParam) of displaying Amiibos within the same series.

Currently limited to 3, but can easily be changed.
Some spacing issues with less than 3, but minor.