### PR TITLE
New commit for AmiiboDetail for Ari

### DIFF
--- a/src/components/AmiiboList/AmiiboDetail.tsx
+++ b/src/components/AmiiboList/AmiiboDetail.tsx
@@ -3,6 +3,7 @@ import { useAppSelector } from '../../redux/hooks';
 import { AmiiboState } from '../../types/Amiibo';
 import Breadcrumb from '../shared/Breadcrumb';
 import { Amiibo } from '../../types/Amiibo';
+import AmiiboCard from '../AmiiboCard';
 import { Link } from 'react-router-dom';
 
 // Styles
@@ -59,17 +60,7 @@ const AmiiboDetail = () => {
                             <p>Release Date: {selectedAmiibo?.release.na}</p>
 
                             <h3>Other Amiibos in the Same Series:</h3>
-                            {
-                                <ul>
-                                    {sameSeries.map((amiibo) => (
-                                        <li key={amiibo.id}>
-                                            <Link to={`/amiibos/${amiibo.tail}-${amiibo.head}`}>
-                                                {amiibo.name}
-                                            </Link>
-                                        </li>
-                                    ))}
-                                </ul>
-                            }
+                            {<AmiiboCard amiiboProps={sameSeries.slice(0, 3)}></AmiiboCard>}
                         </div>
                     </ColMd8>
                 </div>


### PR DESCRIPTION
Improving UI for AmiiboDetail.

Displaying 3 amiibos in the same series, can easily be changed.
Parameterized page correctly updates now with new cards/links.
Minor spacing issue when less than 3 amiibos.