### PR TITLE
Wishlist/Card UI Tweaks #2

### DIFF
--- a/src/components/AmiiboList/AmiiboList.tsx
+++ b/src/components/AmiiboList/AmiiboList.tsx
@@ -16,6 +16,8 @@ import { useNavigate } from 'react-router-dom';
 import { setSelectedAmiibo } from '../../features/amiibo/amiiboSlice';
 import { addToWishlist } from '../../features/user/userAPI';
 import { useAppSelector } from '../../redux/hooks';
+import { getWishlist } from '../../features/user/userAPI';
+import { Amiibo } from '../../types/Amiibo';
 
 // Styles
 import nintendo from '../../assets/super_nintendo_world.png';
@@ -71,6 +73,7 @@ const AmiiboList = () => {
     const [isLoadingMore, setIsLoadingMore] = useState(false);
     const [itemsToShow, setItemsToShow] = useState(CARDS_PER_LOAD);
     const [isModalOpen, setModalOpen] = useState(false);
+    const [wishlist, setWishlist] = useState<Amiibo[]>([]);
 
     const dispatch = useDispatch();
     const navigate = useNavigate();
@@ -89,6 +92,7 @@ const AmiiboList = () => {
             const response = await fetchAmiiboList(`${import.meta.env.VITE_API_URL}`);
             setAmiibos(response);
             setOriginalData(response);
+            handleLoadingWishlist();
             return response;
         },
     });
@@ -105,6 +109,8 @@ const AmiiboList = () => {
         }
         try {
             await addToWishlist(userId, amiibo);
+            const resWish = await getWishlist(userId);
+            setWishlist(resWish);
             toast.success('Added to wishlist');
         } catch (error) {
             if (error instanceof Error) {
@@ -134,6 +140,11 @@ const AmiiboList = () => {
         navigate(path);
         setModalOpen(false);
     };
+
+    const handleLoadingWishlist = async() => {
+        const res = await getWishlist(userId);
+        setWishlist(res);
+    }
 
     return (
         <PageContainer>
@@ -185,7 +196,7 @@ const AmiiboList = () => {
                                 amiibo={amiibo}
                                 onClickDetail={() => handleViewMore(amiibo)}
                                 onClickWishlist={() => handleAddWishlist(amiibo)}
-                                userId={userId}
+                                wishlist={wishlist}
                             />
                         ))}
                     </GridContainer>

--- a/src/components/AmiiboList/Card.tsx
+++ b/src/components/AmiiboList/Card.tsx
@@ -2,10 +2,10 @@
 import { CardContainer, ImageContainer, CardImage, CardTitle, CardFooter, Button, WishButton } from './AmiiboListStyles';
 import {filterWishedAmiibos} from '../../features/amiibo/wishedAmiibos';
 
-const Card = ({ amiibo, onClickDetail, onClickWishlist, userId }) => {
+const Card = ({ amiibo, onClickDetail, onClickWishlist, wishlist }) => {
     // returns an array with the amiibo and a boolean determining whether or not
     // the amiibo exists in the user's wishlist
-    const item = filterWishedAmiibos(amiibo, userId);
+    const item = filterWishedAmiibos(amiibo, wishlist);
 
     return (
         <CardContainer>

--- a/src/components/UserDashboard/ProfilePage.tsx
+++ b/src/components/UserDashboard/ProfilePage.tsx
@@ -1,13 +1,16 @@
 // Dependencies
+/** @jsxImportSource @emotion/react */
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { FiShare } from 'react-icons/fi';
+import { RxCross2 as Icon, RxCross2 } from 'react-icons/rx';
 
 // Components
 import { getUser, getWishlist } from '../../features/user/userAPI';
 import { Amiibo } from '../../types/Amiibo';
 import { User } from '../../types/User';
 import AmiiboItem from './AmiiboItem';
+import WishlistShare from './WishlistShare';
 
 // Styles
 import {
@@ -24,8 +27,12 @@ import {
     RightSection,
     LeftSection, 
     Collection,
+    ModalContainer,
+    modalContent,
+    informationBox,
+    ModalButton,
+    topper,
 } from './ProfilePageStyles';
-
 
 
 function ProfilePage() {
@@ -33,6 +40,13 @@ function ProfilePage() {
     const { userId } = useParams();
     const [user, setUser] = useState<User | null>(null);
     const [wishlist, setWishlist] = useState<Amiibo[]>([]);
+    const [modalOpen, setModalOpen] = useState(false);
+
+
+    const toggleModal = () => {
+        console.log(modalOpen);
+        setModalOpen(!modalOpen);
+    };
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -56,7 +70,18 @@ function ProfilePage() {
                         <OnlineStatus online={user != null} />
                     </ProfileContent>
                     <ProfileCount>CURRENT WISH COUNT: {wishlist?.length}</ProfileCount>
-                    <ShareButton> <FiShare /> Share Wishlist!</ShareButton>
+                    <ShareButton onClick={toggleModal}> <FiShare /> Share Wishlist!</ShareButton>
+                    { modalOpen && (
+                        <ModalContainer>
+                            <div css={modalContent}>
+                            <ModalButton onClick={toggleModal}><Icon/></ModalButton>
+                                <div css={topper}>Share Wish List</div>
+                                <div css={informationBox}>
+                                    <WishlistShare></WishlistShare>
+                                </div>
+                            </div>
+                        </ModalContainer>
+                    )}
                 </ProfileContainer>
 
                 <BottomContainer>

--- a/src/components/UserDashboard/ProfilePageStyles.tsx
+++ b/src/components/UserDashboard/ProfilePageStyles.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import { Button } from '../AmiiboList/AmiiboListStyles';
 
 export const PageContainer = styled.div`
@@ -90,4 +91,77 @@ export const LeftSection = styled.div`
 
 export const Collection = styled.div`  
     margin: auto;
+`;
+
+export const ModalContainer = styled.div`
+    display: flex;
+    align-items: center;
+    position: fixed;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const modalContent = css`
+    background-color: transparent;
+    padding: 10px;
+    position: absolute;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    z-index: 1000;
+`;
+
+export const topper = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+    background-color: white;
+    padding-bottom: 20px;
+    background-color: #f80001;
+    text-align: center;
+    font-size: 20px;
+    font-weight: bold;
+    color: white;
+    min-height: 50px; 
+    border-radius: 15px 15px 0px 0px;
+    border: 2px solid #f80001;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+`;
+
+export const informationBox = css`
+    height: 500px;
+    width: 500px;
+    background-color: white;
+    border-radius: 0 0 15px 15px;
+`;
+
+export const modalTopper = css`
+    height: 500px;
+    width: 500px;
+    border: 2px solid black;
+    border-radius: 5%;
+`;
+
+export const ModalButton = styled.button`
+    height: 50px;
+    width: 50px;
+    margin-bottom: 15px;
+    border-radius: 50%;
+    right: 10px;
+    position: absolute;
+    top: -50px;
+    font-size: 30px;
+    color: white;
+    border: 2px solid #5d5d5d;
+    background-color: #5d5d5d;
+    transition: all 0.3s ease;
+    &:hover {
+        border: 2px solid #282828;
+        background-color: #282828;
+    }
 `;

--- a/src/components/UserDashboard/WishlistShare.tsx
+++ b/src/components/UserDashboard/WishlistShare.tsx
@@ -1,38 +1,37 @@
 import styled from '@emotion/styled';
 import { FaCopy } from "react-icons/fa";
 import { FacebookShare, TwitterShare, EmailShare, RedditShare } from 'react-share-kit';
+import { FiShare } from 'react-icons/fi';
 
 const CopyButton = styled.button`
-  &:hover {
-    border-color: black;
-  }; 
   cursor: pointer;
-  transition: border-color 0.25s;
-  border-radius: 8px;
+  border-radius: 0px 8px 8px 0px;
   border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-
+  padding: 15px;
   color: white;
-  background-color: #646cff;
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  margin-left: auto;
-  margin-right: 35%;
+  background-color: #f80001;
+  margin-left: 10px;
 `;
 
 const CopyContent = styled.div`
   height: 50px;
   width: 300px;
-  border: 5px solid #646cff;
-  border-radius: 8px;
-  background-color: #9298ff;
+  border: 1px solid black;
+  border-radius: 8px 0px 0px 8px;
+  background-color: white;
   text-align: left;
-  color: white;
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  color: black;
   font-size: 1em;
-  font-weight: 500;
-  padding: 0.1em 0.1em;
+  padding-left: 10px;
+  padding-right: 5px;
+  display: grid;
+  align-items: center;
+`;
+
+const CopyText = styled.div`
+  overflow-x: scroll;
+  // hide scrollbar 
+  scrollbar-width: none;
 `;
 
 const CopyBox = styled.div`
@@ -41,30 +40,41 @@ const CopyBox = styled.div`
   padding: 2rem;
 `;
 
-const Share = () => {
+const ShareIcon = styled(FiShare)`
+  font-size: 5rem;
+  padding: 25px;
+`;
+
+const Container = styled.div`
+  text-align: center;
+`;
+
+const WishlistShare = () => {
   const wishlistUrl = window.location.href;
   const text = 'Check out my Amiibo Atlas Wishlist!';
   const title = "User's Amiibo Atlas Wishlist";
 
   return (
-    <div className="sharing-container">
-      <h1>Sharing Your Wishlist! </h1>
-      <p> Invite others to your list: </p>
-      <p>Anyone with this link can view your list!</p>
-      <CopyBox>
-        <CopyContent>      
-        {wishlistUrl}
-      </CopyContent>
-      <CopyButton onClick={()=> {navigator.clipboard.writeText(wishlistUrl)}}><FaCopy /></CopyButton>
-      </CopyBox>
-      <div className='sharing-content'>
-        <FacebookShare url={wishlistUrl} quote={text} />
-        <TwitterShare url={wishlistUrl} title={text} />
-        <EmailShare url={wishlistUrl} subject={title} body={text} />
-        <RedditShare url={wishlistUrl} title={title} />
-      </div>
+    <Container>
+    <ShareIcon></ShareIcon>
+    <p>Share your current wishlist with your friends and family! </p>
+    <CopyBox>
+      <CopyContent> 
+        <CopyText>
+          {wishlistUrl}
+        </CopyText>     
+      
+    </CopyContent>
+    <CopyButton onClick={()=> {navigator.clipboard.writeText(wishlistUrl)}}><FaCopy /></CopyButton>
+    </CopyBox>
+    <div className='sharing-content'>
+      <FacebookShare url={wishlistUrl} quote={text} round={true} />
+      <TwitterShare url={wishlistUrl} title={text} round={true} />
+      <EmailShare url={wishlistUrl} subject={title} body={text} round={true} />
+      <RedditShare url={wishlistUrl} title={title} round={true} />
     </div>
+  </Container>
   )
 }
 
-export default Share
+export default WishlistShare;

--- a/src/features/amiibo/wishedAmiibos.ts
+++ b/src/features/amiibo/wishedAmiibos.ts
@@ -1,16 +1,4 @@
-import { useState, useEffect } from 'react';
-import { Amiibo } from '../../types/Amiibo';
-import { getWishlist } from '../user/userAPI';
-
-export function filterWishedAmiibos(amiibo, userId) {
-    const [status, setStatus] = useState(false);
-
-    const handleWishedStatus = async (userId) => {
-
-        const wishlist = await getWishlist(userId)
-        setStatus(wishlist.map(item => item.image).includes(amiibo.image));
-        
-    }
-    handleWishedStatus(userId);
-    return [amiibo, status];
-};
+export function filterWishedAmiibos(amiibo, wishlist) {
+    return [amiibo, wishlist.map(item => item.image).includes(amiibo.image)];
+    };
+    


### PR DESCRIPTION
# Major Feature Changes:
## Card now turns red upon addition:
* Changed filterWishedAmiibo's function, got the wishlist to load upon page loading. 
## Share Wishlist refactored to be take after Nintendo's model:
![image](https://github.com/Amiibo-Atlas/Amiibo-Atlas/assets/102545685/6121d0a1-14a8-42c2-a954-6cfa542ba7c5)
* the link can be copied by pressing the button
* link is also scrollable
* bottom share buttons are functioning as well.