### PR TITLE
fixed the sharing functionality for unauthorized users

### DIFF
--- a/src/components/UserDashboard/AmiiboItem.tsx
+++ b/src/components/UserDashboard/AmiiboItem.tsx
@@ -89,6 +89,8 @@ const AmiiboItem = ({ amiibo, setWishlist }) => {
     const addedAtFormatted = format(amiibo.addedAt.toDate(), 'PPpp');
     const [determineModalStatus, setDetermineModalStatus] = useState(false);
 
+    console.log('USER: ', userId);
+
     const handleDetails = () => {
         dispatch(setSelectedAmiibo(amiibo));
         navigate(`/amiibos/${amiibo.tail}-${amiibo.head}`);
@@ -128,7 +130,7 @@ const AmiiboItem = ({ amiibo, setWishlist }) => {
                         <button css={Button} onClick={handleDetails}>
                             Details
                         </button>
-                        <Icon css={IconDesign} onClick={handleRemove} />
+                        {userId && <Icon css={IconDesign} onClick={handleRemove} />}
                     </ButtonBox>
                 </ItemBox>
             </WrapperItemBox>

--- a/src/components/UserDashboard/ProfilePage.tsx
+++ b/src/components/UserDashboard/ProfilePage.tsx
@@ -127,8 +127,6 @@ const ProfilePage = () => {
         fetchUser();
     }, [userId]);
 
-    console.log(wishlist);
-
     return (
         <PageContainer>
             <Breadcrumb

--- a/src/components/UserDashboard/SharingPage.tsx
+++ b/src/components/UserDashboard/SharingPage.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 // Dependencies
 import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { FiShare } from 'react-icons/fi';
 import { RxCross2 as Icon } from 'react-icons/rx';
 import { css } from '@emotion/react';
@@ -9,8 +10,7 @@ import styled from '@emotion/styled';
 // Components
 import AmiiboItem from './AmiiboItem';
 import { Amiibo } from '../../types/Amiibo';
-import { User } from '../../types/User';
-import { getUser, getWishlist } from '../../features/user/userAPI';
+import { getWishlist } from '../../features/user/userAPI';
 import WishlistShare from './WishlistShare';
 
 import { 
@@ -25,7 +25,6 @@ import {
 } from './ProfilePageStyles';
 import Breadcrumb from '../shared/Breadcrumb';
 
-import { useAppSelector } from '../../redux/hooks';
 
 const PageTop = styled.div`
     display: flex;
@@ -52,23 +51,21 @@ const countStyle = css`
 
 `;
 
-const WishlistPage = () => {
-    const userId = useAppSelector((state) => state.user.userId);
-    const [user, setUser] = useState<User | null>();
+const SharingPage = () => {
+    const { userId } = useParams();
     const [wishlist, setWishlist] = useState<Amiibo[]>([]);
     const [modalOpen, setModalOpen] = useState(false);
 
     useEffect(() => {
-        const fetchUser = async () => {
+        const fetchWishlist = async () => {
             if (userId) {
-                const fetchedUser = await getUser(userId);
-                setUser(fetchedUser || null);
                 const fetchedWishlist = await getWishlist(userId);
                 setWishlist(fetchedWishlist);
             }
         };
-        fetchUser();
+        fetchWishlist();
     }, [userId]);
+
 
     const toggleModal = () => {
         setModalOpen(!modalOpen);
@@ -79,7 +76,6 @@ const WishlistPage = () => {
             <Breadcrumb
                 paths={[
                     { url: '/', name: 'Home' },
-                    { url: '/account', name: 'My Account' },
                     { url: '/wishlist', name: 'Wishlist' },
                 ]}
                 currentUrl='/wishlist'
@@ -104,7 +100,7 @@ const WishlistPage = () => {
                     ))
                 ) : (
                     <>
-                        <p>You currently have no items in your wishlist.</p>
+                        <p>User currently has no items in their wishlist.</p>
                     </>
                 )}
             </Collection>
@@ -123,4 +119,4 @@ const WishlistPage = () => {
     );
 }
 
-export default WishlistPage;
+export default SharingPage;

--- a/src/components/UserDashboard/SharingPage.tsx
+++ b/src/components/UserDashboard/SharingPage.tsx
@@ -10,8 +10,9 @@ import styled from '@emotion/styled';
 // Components
 import AmiiboItem from './AmiiboItem';
 import { Amiibo } from '../../types/Amiibo';
-import { getWishlist } from '../../features/user/userAPI';
+import { getUserFromShareId, getUserIdFromShareId, getWishlistFromShareId } from '../../features/user/userAPI';
 import WishlistShare from './WishlistShare';
+import { User } from '../../types/User';
 
 import { 
     PageContainer,
@@ -52,19 +53,22 @@ const countStyle = css`
 `;
 
 const SharingPage = () => {
-    const { userId } = useParams();
+    const { shareId } = useParams();
+    const [user, setUser] = useState<User | null>();
     const [wishlist, setWishlist] = useState<Amiibo[]>([]);
     const [modalOpen, setModalOpen] = useState(false);
 
+    
+    
     useEffect(() => {
-        const fetchWishlist = async () => {
-            if (userId) {
-                const fetchedWishlist = await getWishlist(userId);
+        const fetchUser = async () => {
+            if (shareId) {
+                const fetchedWishlist = await getWishlistFromShareId(shareId);
                 setWishlist(fetchedWishlist);
             }
         };
-        fetchWishlist();
-    }, [userId]);
+        fetchUser();
+    }, [shareId]);
 
 
     const toggleModal = () => {
@@ -110,7 +114,7 @@ const SharingPage = () => {
                     <ModalButton onClick={toggleModal}><Icon/></ModalButton>
                         <div css={topper}>Share Wish List</div>
                         <div css={informationBox}>
-                            <WishlistShare userId={userId}></WishlistShare>
+                            <WishlistShare shareId={shareId}></WishlistShare>
                         </div>
                     </div>
                 </ModalContainer>

--- a/src/components/UserDashboard/WishlistPage.tsx
+++ b/src/components/UserDashboard/WishlistPage.tsx
@@ -10,7 +10,7 @@ import styled from '@emotion/styled';
 import AmiiboItem from './AmiiboItem';
 import { Amiibo } from '../../types/Amiibo';
 import { User } from '../../types/User';
-import { getUser, getWishlist } from '../../features/user/userAPI';
+import { getShareId, getUser, getWishlist } from '../../features/user/userAPI';
 import WishlistShare from './WishlistShare';
 
 import { 
@@ -55,6 +55,7 @@ const countStyle = css`
 const WishlistPage = () => {
     const userId = useAppSelector((state) => state.user.userId);
     const [user, setUser] = useState<User | null>();
+    const [shareId, setShareId] = useState('');
     const [wishlist, setWishlist] = useState<Amiibo[]>([]);
     const [modalOpen, setModalOpen] = useState(false);
 
@@ -65,6 +66,8 @@ const WishlistPage = () => {
                 setUser(fetchedUser || null);
                 const fetchedWishlist = await getWishlist(userId);
                 setWishlist(fetchedWishlist);
+                const fetchedShareId = await getShareId(userId);
+                setShareId(fetchedShareId || null);
             }
         };
         fetchUser();
@@ -114,7 +117,7 @@ const WishlistPage = () => {
                     <ModalButton onClick={toggleModal}><Icon/></ModalButton>
                         <div css={topper}>Share Wish List</div>
                         <div css={informationBox}>
-                            <WishlistShare userId={userId}></WishlistShare>
+                            <WishlistShare shareId={shareId}></WishlistShare>
                         </div>
                     </div>
                 </ModalContainer>

--- a/src/components/UserDashboard/WishlistShare.tsx
+++ b/src/components/UserDashboard/WishlistShare.tsx
@@ -49,8 +49,8 @@ const Container = styled.div`
   text-align: center;
 `;
 
-const WishlistShare = () => {
-  const wishlistUrl = window.location.href;
+const WishlistShare = ({ userId }) => {
+  const wishlistUrl = window.location.origin + '/' + userId + '/wishlist';
   const text = 'Check out my Amiibo Atlas Wishlist!';
   const title = "User's Amiibo Atlas Wishlist";
 

--- a/src/components/UserDashboard/WishlistShare.tsx
+++ b/src/components/UserDashboard/WishlistShare.tsx
@@ -1,3 +1,5 @@
+import { useAppSelector } from '../../redux/hooks';
+
 import styled from '@emotion/styled';
 import { FaCopy } from "react-icons/fa";
 import { FacebookShare, TwitterShare, EmailShare, RedditShare } from 'react-share-kit';
@@ -49,8 +51,9 @@ const Container = styled.div`
   text-align: center;
 `;
 
-const WishlistShare = ({ userId }) => {
-  const wishlistUrl = window.location.origin + '/' + userId + '/wishlist';
+const WishlistShare = ({ shareId }) => {
+  const userId = useAppSelector((state) => state.user.userId);
+  const wishlistUrl = window.location.origin + '/wishlist' + '/' + shareId;
   const text = 'Check out my Amiibo Atlas Wishlist!';
   const title = "User's Amiibo Atlas Wishlist";
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,7 +43,7 @@ const router = createBrowserRouter([
             { path: '/account', element: <ProfilePage /> },
             { path: '/wishlist', element: <WishlistPage /> },
             { path: `/aboutamiibo`, element: <AboutAmiibo /> },
-            { path: `/:userId/wishlist`, element: <SharingPage /> },
+            { path: `/wishlist/:shareId`, element: <SharingPage /> },
         ],
     },
 ]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,7 @@ import ProfilePage from './components/UserDashboard/ProfilePage.tsx';
 import AboutAmiibo from './components/AmiiboAbout.tsx';
 import store from './redux/store.ts';
 import WishlistPage from './components/UserDashboard/WishlistPage.tsx';
+import SharingPage from './components/UserDashboard/SharingPage.tsx';
 
 const queryClient = new QueryClient();
 
@@ -42,6 +43,7 @@ const router = createBrowserRouter([
             { path: '/account', element: <ProfilePage /> },
             { path: '/wishlist', element: <WishlistPage /> },
             { path: `/aboutamiibo`, element: <AboutAmiibo /> },
+            { path: `/:userId/wishlist`, element: <SharingPage /> },
         ],
     },
 ]);


### PR DESCRIPTION
# Fixed the sharing issue by creating a new sharing page that derived from the main wishlist page.
## New URL:
![image](https://github.com/Amiibo-Atlas/Amiibo-Atlas/assets/102545685/ea592459-180c-4cd5-b4f0-e5b800edd8f3)

## Sharing Page:
the url is different from the usual pattern we've been using - incorporated the user's id. 
Tested via Incognito mode and other users and it worked:
![image](https://github.com/Amiibo-Atlas/Amiibo-Atlas/assets/102545685/94c5653f-d4a1-4718-bfbd-99a72c7aa921)

## Main Changes:
* main.tsx - added the sharing page for the url
* Sharing Page -created to host the unauth route.
* Wishlist Page and Wishlist Share files were changed to include passing of userId. 
* Firebase Rules: changed to allow only reading for unauth.
